### PR TITLE
Disclaimer about paid ChatGPT4 account

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ So, if you've ever screamed into the abyss because Git just won't cooperate, AGi
 To start speaking the Git language without actually learning it, you'll need:
 
 - Python 3.11 or higher (A magical snake, with magical powers)
-- OpenAI API key (No less magical)
+- OpenAI Plus account and API key ChatGPT4 (No less magical)
 
 ### Then, continue to install from PyPI 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ So, if you've ever screamed into the abyss because Git just won't cooperate, AGi
 To start speaking the Git language without actually learning it, you'll need:
 
 - Python 3.11 or higher (A magical snake, with magical powers)
-- OpenAI Plus account and API key ChatGPT4 (No less magical)
+- OpenAI Plus account and API key for ChatGPT4 (No less magical)
 
 ### Then, continue to install from PyPI 
 


### PR DESCRIPTION
Update README to cover the fact that a ChatGPT commercial account is needed, so people do not try to get it working with a free account.

The relevant error is

```
openai.error.InvalidRequestError: The model `gpt-4-0125-preview does not exist or you do not have access to it.`
```